### PR TITLE
Fix medication history update and add medicationDate to API response

### DIFF
--- a/app/DataTransfer/MedicationHistory/MedicationHistoryDetail.php
+++ b/app/DataTransfer/MedicationHistory/MedicationHistoryDetail.php
@@ -11,6 +11,7 @@ use Domain\Drug\DrugId;
 use Domain\Drug\DrugName;
 use Domain\Drug\DrugUrl;
 use Domain\MedicationHistory\Amount;
+use Domain\MedicationHistory\MedicationDate;
 use Domain\MedicationHistory\MedicationHistory;
 use Domain\MedicationHistory\MedicationHistoryId;
 use Domain\MedicationHistory\MedicationNote;
@@ -36,6 +37,8 @@ class MedicationHistoryDetail
     #[Property(type: 'string', nullable: true, example: '朝食後に服用')]
     public MedicationNote $note;
     #[Property(type: 'string', example: '2022-01-01T00:00:00+09:00')]
+    public MedicationDate $medicationDate;
+    #[Property(type: 'string', example: '2022-01-01T00:00:00+09:00')]
     public CreatedAt $createdAt;
     #[Property(type: 'string', example: '2022-03-16T00:00:00+09:00')]
     public UpdatedAt $updatedAt;
@@ -51,6 +54,7 @@ class MedicationHistoryDetail
         $this->drugName = $drug->getName();
         $this->drugUrl = $drug->getUrl();
         $this->note = $medicationHistory->getNote();
+        $this->medicationDate = $medicationHistory->getMedicationDate();
         $this->createdAt = $medicationHistory->getCreatedAt();
         $this->updatedAt = $medicationHistory->getUpdatedAt();
     }

--- a/app/Http/Api/Common/Responder/BaseResponder.php
+++ b/app/Http/Api/Common/Responder/BaseResponder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Api\Common\Responder;
 
 use Domain\Base\BaseDateTime;
+use Domain\Base\BaseTime;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\JsonResponse;
 use OpenApi\Attributes\Property;
@@ -57,6 +58,10 @@ abstract class BaseResponder implements Responsable
     {
         if (true === \is_object($data)) {
             if ($data instanceof BaseDateTime) {
+                return $data->getIsoString();
+            }
+
+            if ($data instanceof BaseTime) {
                 return $data->getIsoString();
             }
 

--- a/app/Http/Api/MedicationHistory/Requests/UpdateMedicationHistoryRequest.php
+++ b/app/Http/Api/MedicationHistory/Requests/UpdateMedicationHistoryRequest.php
@@ -51,6 +51,6 @@ class UpdateMedicationHistoryRequest extends ApiRequest
         if (is_null($value)) {
             return null;
         }
-        return new MedicationDate($value);
+        return MedicationDate::forStringTime($value);
     }
 }

--- a/infra/EloquentRepository/MedicationHistoryRepository.php
+++ b/infra/EloquentRepository/MedicationHistoryRepository.php
@@ -111,6 +111,7 @@ class MedicationHistoryRepository implements MedicationHistoryRepositoryInterfac
 
         $model->amount = $medicationHistory->getAmount()->getRawValue();
         $model->note = $medicationHistory->getNote()->getRawValue();
+        $model->medication_date = $medicationHistory->getMedicationDate()->getSqlTimeStamp();
 
         $model->save();
 

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -531,6 +531,10 @@
                         "example": "朝食後に服用",
                         "nullable": true
                     },
+                    "medicationDate": {
+                        "type": "string",
+                        "example": "2022-01-01T00:00:00+09:00"
+                    },
                     "createdAt": {
                         "type": "string",
                         "example": "2022-01-01T00:00:00+09:00"


### PR DESCRIPTION
## Summary
- Fix `UpdateMedicationHistoryRequest` to use `MedicationDate::forStringTime()` instead of direct constructor (TypeError: int expected, string given)
- Add `medication_date` to `EloquentRepository::update()` (was saving only amount and note)
- Add `medicationDate` field to `MedicationHistoryDetail` DTO and OpenAPI spec
- Add `BaseTime` ISO string conversion in `BaseResponder::objectToArray()` (BaseTime subclasses were serialized as UNIX timestamps instead of ISO strings)

## Test plan
- [ ] PUT `/api/medication_histories/{id}` with `medication_date` returns updated value
- [ ] `medicationDate` field appears in API response as ISO 8601 string
- [ ] Existing GET endpoints continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)